### PR TITLE
in bash use (( )) for numeric comparisons

### DIFF
--- a/sqspoll.sh
+++ b/sqspoll.sh
@@ -82,13 +82,13 @@ while (true); do
         if [[ $COUNT != "" ]]; then
             let COUNT--
             log "Count: $COUNT"
-            [[ $COUNT < 1 ]] && exit
+            (( $COUNT < 1 )) && exit
         fi
     fi
     if [[ $LOOP != "" ]]; then
         let LOOP--
         log "Loop: $LOOP"
-        [[ $LOOP < 1 ]] && exit
+        (( $LOOP < 1 )) && exit
     fi
 done
 


### PR DESCRIPTION
// thank you for publishing this script! I'm not using the COUNT or LOOP personally, but this jumped out at me.

short explanation of why:
```
# [[ 9 > 11 ]] && echo yes
yes
```

longer explanation: https://stackoverflow.com/questions/18668556/comparing-numbers-in-bash